### PR TITLE
minor changes to LanguageServiceProfiling:

### DIFF
--- a/vsintegration/Utils/LanguageServiceProfiling/App.config
+++ b/vsintegration/Utils/LanguageServiceProfiling/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
-    </startup>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0" />
+  </startup>
 </configuration>

--- a/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
+++ b/vsintegration/Utils/LanguageServiceProfiling/LanguageServiceProfiling.fsproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <FSharpSourcesRoot>$(MSBuildProjectDirectory)\..\..\..\src</FSharpSourcesRoot>
     <ProjectLanguage>FSharp</ProjectLanguage>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <Import Project="$(FSharpSourcesRoot)\FSharpSource.settings.targets" />
   <PropertyGroup>
@@ -14,7 +15,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>LanguageServiceProfiling</RootNamespace>
     <AssemblyName>LanguageServiceProfiling</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFSharpCoreVersion>4.4.1.0</TargetFSharpCoreVersion>
     <Name>LanguageServiceProfiling</Name>
@@ -27,7 +28,7 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DocumentationFile>
     </DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
@@ -39,13 +40,16 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <PlatformTarget>x86</PlatformTarget>
     <DocumentationFile>
     </DocumentationFile>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Proto|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '11.0'">

--- a/vsintegration/Utils/LanguageServiceProfiling/Program.fs
+++ b/vsintegration/Utils/LanguageServiceProfiling/Program.fs
@@ -2,12 +2,13 @@
 open System
 open LanguageServiceProfiling
 open System.Diagnostics
+open System.Collections.Generic
 
 [<EntryPoint>]
 let main argv = 
     let options = Options.FCS argv.[0]
     let checker = FSharpChecker.Create()
-
+    let waste = new ResizeArray<int array>()
     let check() =
         printfn "ParseAndCheckProject(FCS)..."
         let sw = Stopwatch.StartNew()
@@ -17,7 +18,10 @@ let main argv =
         else printfn "Finished successfully in %O" sw.Elapsed
         ()
     
-    printfn "Press <C> for check the project, <G> for GC.Collect(2), <Enter> for exit."
+    let wasteMemory () =
+        waste.Add(Array.zeroCreate (1024 * 1024 * 25))
+
+    printfn "Press <C> for check the project, <G> for GC.Collect(2), <W> for wasting memory, <M> to reclaim waste <Enter> for exit."
     let rec loop() =
         match Console.ReadKey().Key with
         | ConsoleKey.C -> 
@@ -29,6 +33,10 @@ let main argv =
             GC.Collect 2
             printfn "GC is done in %O" sw.Elapsed
             loop()
+        | ConsoleKey.W ->
+            wasteMemory()
+        | ConsoleKey.M ->
+            waste.Clear()
         | ConsoleKey.Enter -> ()
         | _ -> loop()
     loop()


### PR DESCRIPTION
* change target framework (so can build with vs2015)
* change to x86
* add <W> and <M> keys to waste some memory (loads 100mb array and put it in a resizearray) or reclaim waste (clear the resizearray) for extra memory pressure